### PR TITLE
Add support for .NET Framework 4.7 and higher

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,25 @@
+name: .NET
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
+    - name: Test
+      run: dotnet test --no-build --verbosity normal

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -23,5 +23,11 @@ jobs:
       run: dotnet restore
     - name: Build
       run: dotnet build --no-restore -c Release
+    - name: Pack
+      run: dotnet pack --no-build -c Release /p:PackageVersion=0.0.0-local
     - name: Test
       run: dotnet test --no-build -c Release --verbosity normal
+    - name: Test package
+      run: |
+        dotnet nuget add source ${{ github.workspace }}/pack -n="LocalNLopt"
+        dotnet build -c Release ./NLoptNet.NuGet.Tests/NLoptNet.NuGet.Tests.csproj

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -17,8 +17,13 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: | 
+            2.1.x
             3.1.x
             6.0.x
+    - name: Remove signing
+      run: |
+        dotnet tool install --global replace-in-file 
+        replace-in-file .\nloptnet\nloptnet.csproj -set "SignAssembly>true" "SignAssembly>false"
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -26,8 +26,9 @@ jobs:
     - name: Pack
       run: dotnet pack --no-build -c Release /p:PackageVersion=0.0.0-local
     - name: Test
-      run: dotnet test --no-build -c Release --verbosity normal
+      run: dotnet test --no-build -c Release
     - name: Test package
       run: |
         dotnet nuget add source ${{ github.workspace }}/pack -n="LocalNLopt"
-        dotnet build -c Release ./NLoptNet.NuGet.Tests/NLoptNet.NuGet.Tests.csproj
+        dotnet test ./NLoptNet.NuGet.Tests/NLoptNet.NuGet.Tests.csproj -c Release /property:Platform="AnyCPU" 
+        dotnet test ./NLoptNet.NuGet.Tests/NLoptNet.NuGet.Tests.csproj -c Release /property:Platform="x64"

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,7 +16,9 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: | 
+            3.1.x
+            6.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -22,6 +22,6 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --no-restore
+      run: dotnet build --no-restore -c Release
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test --no-build -c Release --verbosity normal

--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,4 @@ $RECYCLE.BIN/
 
 .idea/
 .vs/
+pack/

--- a/NLoptNet.NuGet.Tests/NLoptNet.NuGet.Tests.csproj
+++ b/NLoptNet.NuGet.Tests/NLoptNet.NuGet.Tests.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFrameworks>net47;net48;netcoreapp3.1;net6.0</TargetFrameworks>
-		<Platforms>AnyCPU</Platforms>
-        <IsPackable>false</IsPackable>
-		<LangVersion>latest</LangVersion>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>net47;net48;netcoreapp3.1;net6.0</TargetFrameworks>
+    <Platforms>AnyCPU</Platforms>
+    <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
 
   <PropertyGroup>
     <PlatformTarget>$(Platform)</PlatformTarget>
@@ -25,16 +25,16 @@
   </PropertyGroup>
 
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-        <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
-        <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
-        <PackageReference Include="coverlet.collector" Version="3.1.0">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="NLoptNet" Version="0.0.0-local" />
-    </ItemGroup>
-
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PrivateAssets>all</PrivateAssets>
+    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="NLoptNet" Version="0.0.0-local" />
+  </ItemGroup>
+  
 </Project>

--- a/NLoptNet.NuGet.Tests/NLoptNet.NuGet.Tests.csproj
+++ b/NLoptNet.NuGet.Tests/NLoptNet.NuGet.Tests.csproj
@@ -1,0 +1,40 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>net47;net48;netcoreapp3.1;net6.0</TargetFrameworks>
+		<Platforms>AnyCPU</Platforms>
+        <IsPackable>false</IsPackable>
+		<LangVersion>latest</LangVersion>
+    </PropertyGroup>
+
+  <PropertyGroup>
+    <PlatformTarget>$(Platform)</PlatformTarget>
+    <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>  
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <DebugType>full</DebugType>         
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <DefineConstants>TRACE;RELEASE</DefineConstants>
+    <DebugType>none</DebugType>
+    <DebugSymbols>false</DebugSymbols>        
+  </PropertyGroup>
+
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+        <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
+        <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
+        <PackageReference Include="coverlet.collector" Version="3.1.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="NLoptNet" Version="0.0.0-local" />
+    </ItemGroup>
+
+</Project>

--- a/NLoptNet.NuGet.Tests/SolverTests.cs
+++ b/NLoptNet.NuGet.Tests/SolverTests.cs
@@ -1,0 +1,169 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Diagnostics;
+
+namespace NLoptNet.NuGet.Tests
+{
+	[TestClass]
+	public class SolverTests
+	{
+		[TestMethod]
+		public void TestBasicParabolaNoDerivative()
+		{
+			for (int i = 0; i <= (int)NLoptAlgorithm.GN_ESCH; i++)
+			{
+				var algorithm = (NLoptAlgorithm)i;
+				var algStr = algorithm.ToString();
+				if (algStr.Contains("AUGLAG") || algStr.Contains("MLSL"))
+					continue;
+				if (algStr.Substring(0, 3).Contains("D_"))
+					continue;
+				var sw = Stopwatch.StartNew();
+				int count = 0;
+				using (var solver = new NLoptSolver(algorithm, 1, 0.01, 2000))
+				{
+					solver.SetLowerBounds(new[] { -10.0 });
+					solver.SetUpperBounds(new[] { 100.0 });
+					solver.SetMinObjective(variables =>
+					{
+						count++;
+						return Math.Pow(variables[0] - 3.0, 2.0) + 4.0;
+					});
+					double? final;
+					var data = new[] { 2.0 };
+					var result = solver.Optimize(data, out final);
+					//Assert.AreEqual(NloptResult.XTOL_REACHED, result);
+					//if (result == NloptResult.MAXEVAL_REACHED || result == NloptResult.XTOL_REACHED)
+					//Assert.AreEqual(4.0, final.Value, 0.1);
+					//	Assert.AreEqual(3.0, data[0], 0.01);
+					Trace.WriteLine(string.Format("D:{0:F3}, R:{1:F3}, A:{2}, {3}", data[0], final.GetValueOrDefault(-1), algorithm, result));
+				}
+				Trace.WriteLine("Elapsed: " + sw.ElapsedMilliseconds + "ms, Iterations: " + count);
+			}
+		}
+
+		[TestMethod]
+		public void TestBasicParabola()
+		{
+			for (int i = 0; i <= (int)NLoptAlgorithm.GN_ESCH; i++)
+			{
+				var algorithm = (NLoptAlgorithm)i;
+				var algStr = algorithm.ToString();
+				if (algStr.Contains("AUGLAG") || algStr.Contains("MLSL"))
+					continue;
+				var sw = Stopwatch.StartNew();
+				int count = 0;
+				using (var solver = new NLoptSolver(algorithm, 1, 0.0001, 2000))
+				{
+					solver.SetLowerBounds(new[] { -10.0 });
+					solver.SetUpperBounds(new[] { 100.0 });
+					solver.SetMinObjective((variables, gradient) =>
+					{
+						count++;
+						if (gradient != null)
+							gradient[0] = (variables[0] - 3.0) * 2.0;
+						return Math.Pow(variables[0] - 3.0, 2.0) + 4.0;
+					});
+					double? final;
+					var data = new[] { 2.0 };
+					var result = solver.Optimize(data, out final);
+					//Assert.AreEqual(NloptResult.XTOL_REACHED, result);
+					//if (result == NloptResult.MAXEVAL_REACHED || result == NloptResult.XTOL_REACHED)
+					//Assert.AreEqual(4.0, final.Value, 0.1);
+					//	Assert.AreEqual(3.0, data[0], 0.01);
+					Trace.WriteLine(string.Format("D:{0:F3}, R:{1:F3}, A:{2}, {3}", data[0], final.GetValueOrDefault(-1), algorithm, result));
+				}
+				Trace.WriteLine("Elapsed: " + sw.ElapsedMilliseconds + "ms, Iterations: " + count);
+			}
+		}
+
+		[TestMethod]
+		public void FindParabolaMinimum()
+		{
+			using (var solver = new NLoptSolver(NLoptAlgorithm.LN_COBYLA, 1, 0.001, 100))
+			{
+				solver.SetLowerBounds(new[] { -10.0 });
+				solver.SetUpperBounds(new[] { 100.0 });
+
+				solver.SetMinObjective(variables => Math.Pow(variables[0] - 3.0, 2.0) + 4.0);
+				double? finalScore;
+				var initialValue = new[] { 2.0 };
+				var result = solver.Optimize(initialValue, out finalScore);
+
+				Assert.AreEqual(NloptResult.XTOL_REACHED, result);
+				Assert.AreEqual(3.0, initialValue[0], 0.1);
+				Assert.AreEqual(4.0, finalScore.GetValueOrDefault(), 0.1);
+			}
+		}
+
+		[TestMethod]
+		public void FindParabolaMinimumWithDerivative()
+		{
+			using (var solver = new NLoptSolver(NLoptAlgorithm.LD_AUGLAG, 1, 0.01, 100, NLoptAlgorithm.LN_NELDERMEAD))
+			{
+				solver.SetLowerBounds(new[] { -10.0 });
+				solver.SetUpperBounds(new[] { 100.0 });
+				solver.AddLessOrEqualZeroConstraint((variables, gradient) =>
+				{
+					if (gradient != null)
+						gradient[0] = 1.0;
+					return variables[0] - 100.0;
+				});
+				solver.SetMinObjective((variables, gradient) =>
+				{
+					if (gradient != null)
+						gradient[0] = (variables[0] - 3.0) * 2.0;
+					return Math.Pow(variables[0] - 3.0, 2.0) + 4.0;
+				});
+				double? finalScore;
+				var initialValue = new[] { 2.0 };
+				var result = solver.Optimize(initialValue, out finalScore);
+
+				Assert.AreEqual(3.0, initialValue[0], 0.01);
+				Assert.AreEqual(4.0, finalScore.GetValueOrDefault(), 0.01);
+			}
+		}
+
+		[TestMethod]
+		public void SetAndGetAbsToleranceFuncVal()
+		{
+			using (var solver = new NLoptSolver(NLoptAlgorithm.LD_AUGLAG, 1, 0.01, 100, NLoptAlgorithm.LN_NELDERMEAD))
+			{
+				const double expectedValue = Math.PI;
+
+				solver.SetAbsoluteToleranceOnFunctionValue(expectedValue);
+				var solverTolerance = solver.GetAbsoluteToleranceOnFunctionValue();
+
+				Assert.AreEqual(expectedValue, solverTolerance);
+			}
+		}
+
+		[TestMethod]
+		public void SetAndGetRelToleranceFuncVal()
+		{
+			using (var solver = new NLoptSolver(NLoptAlgorithm.LD_AUGLAG, 1, 0.01, 100, NLoptAlgorithm.LN_NELDERMEAD))
+			{
+				const double expectedValue = Math.PI;
+
+				solver.SetRelativeToleranceOnFunctionValue(expectedValue);
+				var solverTolerance = solver.GetRelativeToleranceOnFunctionValue();
+
+				Assert.AreEqual(expectedValue, solverTolerance);
+			}
+		}
+
+		[TestMethod]
+		public void SetAndGetRelToleranceOptParam()
+		{
+			using (var solver = new NLoptSolver(NLoptAlgorithm.LD_AUGLAG, 1, 0.01, 100, NLoptAlgorithm.LN_NELDERMEAD))
+			{
+				const double expectedValue = Math.PI;
+
+				solver.SetRelativeToleranceOnOptimizationParameter(expectedValue);
+				var solverTolerance = solver.GetRelativeToleranceOnOptimizationParameter();
+
+				Assert.AreEqual(expectedValue, solverTolerance);
+			}
+		}
+	}
+}

--- a/NLoptNet.Tests/NLoptNet.Tests.csproj
+++ b/NLoptNet.Tests/NLoptNet.Tests.csproj
@@ -24,10 +24,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/NLoptNet.Tests/NLoptNet.Tests.csproj
+++ b/NLoptNet.Tests/NLoptNet.Tests.csproj
@@ -7,6 +7,20 @@
     <IsPackable>false</IsPackable>
     <Platforms>x64</Platforms>
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
+    <PlatformTarget>$(Platform)</PlatformTarget>
+    <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>  
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <DebugType>full</DebugType>         
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <DefineConstants>TRACE;RELEASE</DefineConstants>
+    <DebugType>none</DebugType>
+    <DebugSymbols>false</DebugSymbols>        
   </PropertyGroup>
 
   <ItemGroup>

--- a/NLoptNet.sln
+++ b/NLoptNet.sln
@@ -29,6 +29,7 @@ Global
 		{3FBAF56F-C4EB-4AB0-82EB-947ADD2E6E97}.Release|Any CPU.ActiveCfg = Release|x64
 		{3FBAF56F-C4EB-4AB0-82EB-947ADD2E6E97}.Release|x64.ActiveCfg = Release|x64
 		{3FBAF56F-C4EB-4AB0-82EB-947ADD2E6E97}.Release|x64.Build.0 = Release|x64
+		{3FBAF56F-C4EB-4AB0-82EB-947ADD2E6E97}.Debug|Any CPU.Build.0 = Debug|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NLoptNet.sln
+++ b/NLoptNet.sln
@@ -30,6 +30,7 @@ Global
 		{3FBAF56F-C4EB-4AB0-82EB-947ADD2E6E97}.Release|x64.ActiveCfg = Release|x64
 		{3FBAF56F-C4EB-4AB0-82EB-947ADD2E6E97}.Release|x64.Build.0 = Release|x64
 		{3FBAF56F-C4EB-4AB0-82EB-947ADD2E6E97}.Debug|Any CPU.Build.0 = Debug|x64
+		{3FBAF56F-C4EB-4AB0-82EB-947ADD2E6E97}.Release|Any CPU.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NLoptNet.sln
+++ b/NLoptNet.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLoptNet", "NLoptNet\NLoptN
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLoptNet.Tests", "NLoptNet.Tests\NLoptNet.Tests.csproj", "{3FBAF56F-C4EB-4AB0-82EB-947ADD2E6E97}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NLoptNet.NuGet.Tests", "NLoptNet.NuGet.Tests\NLoptNet.NuGet.Tests.csproj", "{6781C965-513E-4717-A0AD-A1EF339DDEC1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -31,6 +33,10 @@ Global
 		{3FBAF56F-C4EB-4AB0-82EB-947ADD2E6E97}.Release|x64.Build.0 = Release|x64
 		{3FBAF56F-C4EB-4AB0-82EB-947ADD2E6E97}.Debug|Any CPU.Build.0 = Debug|x64
 		{3FBAF56F-C4EB-4AB0-82EB-947ADD2E6E97}.Release|Any CPU.Build.0 = Release|x64
+		{6781C965-513E-4717-A0AD-A1EF339DDEC1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6781C965-513E-4717-A0AD-A1EF339DDEC1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6781C965-513E-4717-A0AD-A1EF339DDEC1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6781C965-513E-4717-A0AD-A1EF339DDEC1}.Release|x64.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NLoptNet/NLoptNet.csproj
+++ b/NLoptNet/NLoptNet.csproj
@@ -3,24 +3,32 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>NLoptNet</RootNamespace>
-    <PackageVersion>1.3.0</PackageVersion>
-  </PropertyGroup>
-
-  <PropertyGroup>
+    <PackageVersion>2.0.0</PackageVersion>
+	<Platforms>AnyCPU;x64</Platforms>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-  </PropertyGroup>
-  
-  <PropertyGroup>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <PackageOutputPath>../pack</PackageOutputPath>
+    <PlatformTarget>$(Platform)</PlatformTarget>
+    <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>  
     <SignAssembly>false</SignAssembly>
-  </PropertyGroup>
-  <PropertyGroup>
     <AssemblyOriginatorKeyFile>Signer.pfx</AssemblyOriginatorKeyFile>
     <Authors>Brannon King</Authors>
     <PackageTags>NLopt NLoptNet Optimization Minimization Simplex Stogo Cobyla BFGS</PackageTags>
-    <PackageReleaseNotes>Updated NLoptNet to .Net Standard 2.0, added Linux target, removed legacy project format support.</PackageReleaseNotes>
+    <PackageReleaseNotes>Support for .NET Standard and .NET Framework</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/BrannonKing/NLoptNet</RepositoryUrl>
     <DelaySign>false</DelaySign>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <DebugType>full</DebugType>         
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <DefineConstants>TRACE;RELEASE</DefineConstants>
+    <DebugType>none</DebugType>
+    <DebugSymbols>false</DebugSymbols>        
   </PropertyGroup>
 
   <ItemGroup>

--- a/NLoptNet/NLoptNet.csproj
+++ b/NLoptNet/NLoptNet.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net47</TargetFrameworks>
@@ -10,7 +10,7 @@
     <PackageOutputPath>../pack</PackageOutputPath>
     <PlatformTarget>$(Platform)</PlatformTarget>
     <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>  
-    <SignAssembly>false</SignAssembly>
+    <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Signer.pfx</AssemblyOriginatorKeyFile>
     <Authors>Brannon King</Authors>
     <PackageTags>NLopt NLoptNet Optimization Minimization Simplex Stogo Cobyla BFGS</PackageTags>

--- a/NLoptNet/NLoptNet.csproj
+++ b/NLoptNet/NLoptNet.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   
   <PropertyGroup>
-    <SignAssembly>true</SignAssembly>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>Signer.pfx</AssemblyOriginatorKeyFile>

--- a/NLoptNet/NLoptNet.csproj
+++ b/NLoptNet/NLoptNet.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net47</TargetFrameworks>
     <RootNamespace>NLoptNet</RootNamespace>
-    <PackageVersion>2.0.0</PackageVersion>
+    <PackageVersion>1.4.0</PackageVersion>
 	<Platforms>AnyCPU;x64</Platforms>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/NLoptNet/NLoptNet.csproj
+++ b/NLoptNet/NLoptNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net47</TargetFrameworks>
     <RootNamespace>NLoptNet</RootNamespace>
     <PackageVersion>2.0.0</PackageVersion>
 	<Platforms>AnyCPU;x64</Platforms>
@@ -35,31 +35,37 @@
     <None Include="Signer.pfx" />
   </ItemGroup>
   <ItemGroup>
-    <None Update="runtimes\linux-arm64\native\nlopt.so" Pack="true" PackagePath="runtimes/linux-arm64/native/nlopt.so">
+    <None Include="runtimes\linux-arm64\native\nlopt.so" Pack="true" PackagePath="runtimes/linux-arm64/native/nlopt.so">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="runtimes\linux-x64\native\nlopt.so" Pack="true" PackagePath="runtimes/linux-x64/native/nlopt.so">
+    <None Include="runtimes\linux-x64\native\nlopt.so" Pack="true" PackagePath="runtimes/linux-x64/native/nlopt.so">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="runtimes\linux-musl-x64\native\nlopt.so" Pack="true" PackagePath="runtimes/linux-musl-x64/native/nlopt.so">
+    <None Include="runtimes\linux-musl-x64\native\nlopt.so" Pack="true" PackagePath="runtimes/linux-musl-x64/native/nlopt.so">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="runtimes\win-x64\native\nlopt.dll" Pack="true" PackagePath="runtimes/win-x64/native/nlopt.dll">
+    <None Include="runtimes\win-x64\native\nlopt.dll" Pack="true" PackagePath="runtimes/win-x64/native/nlopt.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="runtimes\win-x64\native\nlopt.exp" Pack="true" PackagePath="runtimes/win-x64/native/nlopt.exp">
+    <None Include="runtimes\win-x64\native\nlopt.exp" Pack="true" PackagePath="runtimes/win-x64/native/nlopt.exp">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="runtimes\win-x64\native\nlopt.lib" Pack="true" PackagePath="runtimes/win-x64/native/nlopt.lib">
+    <None Include="runtimes\win-x64\native\nlopt.lib" Pack="true" PackagePath="runtimes/win-x64/native/nlopt.lib">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="runtimes\win-x86\native\nlopt.dll" Pack="true" PackagePath="runtimes/win-x86/native/nlopt.dll">
+    <None Include="runtimes\win-x86\native\nlopt.dll" Pack="true" PackagePath="runtimes/win-x86/native/nlopt.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="runtimes\win-x86\native\nlopt.exp" Pack="true" PackagePath="runtimes/win-x86/native/nlopt.exp">
+    <None Include="runtimes\win-x86\native\nlopt.exp" Pack="true" PackagePath="runtimes/win-x86/native/nlopt.exp">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="runtimes\win-x86\native\nlopt.lib" Pack="true" PackagePath="runtimes/win-x86/native/nlopt.lib">
+    <None Include="runtimes\win-x86\native\nlopt.lib" Pack="true" PackagePath="runtimes/win-x86/native/nlopt.lib">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="runtimes\win-x86\native\nlopt.dll" Pack="true" PackagePath="lib/net47/nlopt_x32.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="runtimes\win-x64\native\nlopt.dll" Pack="true" PackagePath="lib/net47/nlopt_x64.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/NLoptNet/NLoptSolver.cs
+++ b/NLoptNet/NLoptSolver.cs
@@ -12,7 +12,7 @@ namespace NLoptNet
 	/// <summary>
 	/// This class wraps the NLopt C library. Be sure to dispose it when done.
 	/// </summary>
-	public class NLoptSolver : IDisposable
+	public partial class NLoptSolver : IDisposable
 	{
 #if MONO
 				[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -53,85 +53,6 @@ namespace NLoptNet
 			IntPtr data
 		);
 #endif
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern void nlopt_version(out int major, out int minor, out int bugfix);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern IntPtr nlopt_create(NLoptAlgorithm algorithm, uint n);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern void nlopt_destroy(IntPtr opt);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
-		private static extern NloptResult nlopt_optimize(IntPtr opt, double[] x, ref double result);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NloptResult nlopt_set_min_objective(IntPtr opt, nlopt_func f, IntPtr data);
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NloptResult nlopt_set_max_objective(IntPtr opt, nlopt_func f, IntPtr data);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NLoptAlgorithm nlopt_get_algorithm(IntPtr opt);
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern uint nlopt_get_dimension(IntPtr opt);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NloptResult nlopt_set_lower_bounds(IntPtr opt, double[] lowerBounds);
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NloptResult nlopt_set_upper_bounds(IntPtr opt, double[] upperBounds);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NloptResult nlopt_add_inequality_constraint(IntPtr opt, nlopt_func fc, IntPtr data, double tolerance);
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NloptResult nlopt_add_equality_constraint(IntPtr opt, nlopt_func fc, IntPtr data, double tolerance);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NloptResult nlopt_add_equality_mconstraint(IntPtr opt, uint m, nlopt_mfunc fc, IntPtr data, double[] tolerances);
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NloptResult nlopt_add_inequality_mconstraint(IntPtr opt, uint m, nlopt_mfunc fc, IntPtr data, double[] tolerances);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NloptResult nlopt_set_xtol_rel(IntPtr opt, double tolerance);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NloptResult nlopt_set_local_optimizer(IntPtr opt, IntPtr local);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern void nlopt_set_maxeval(IntPtr opt, int maxeval);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NloptResult nlopt_force_stop(IntPtr opt);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NloptResult nlopt_set_initial_step(IntPtr opt, double[] dx);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NloptResult nlopt_set_initial_step1(IntPtr opt, double dx);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NloptResult nlopt_set_ftol_rel(IntPtr opt, double tol);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NloptResult nlopt_set_ftol_abs(IntPtr opt, double tol);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NloptResult nlopt_set_xtol_abs1(IntPtr opt, double tol);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NloptResult nlopt_set_xtol_abs(IntPtr opt, double[] tol);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern double nlopt_get_ftol_rel(IntPtr opt);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern double nlopt_get_ftol_abs(IntPtr opt);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern double nlopt_get_xtol_rel(IntPtr opt);
-
-		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
-		private static extern NloptResult nlopt_get_xtol_abs(IntPtr opt, out double[] tol);
 
 		private IntPtr _opt;
 		private readonly Dictionary<Delegate, nlopt_func> _funcCache = new Dictionary<Delegate, nlopt_func>();

--- a/NLoptNet/NLoptSolver_netfx.cs
+++ b/NLoptNet/NLoptSolver_netfx.cs
@@ -1,0 +1,303 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace NLoptNet
+{
+	public partial class NLoptSolver
+	{
+		private static bool Is64Bit => IntPtr.Size == 8;
+		private const string Subscript32 = @"_x32";
+		private const string Subscript64 = @"_x64";
+		private static string Subscript => Is64Bit ? Subscript64 : Subscript32;
+		private const string NLopt32 = "nlopt_x32.dll";
+		private const string NLopt64 = "nlopt_x64.dll";
+
+		[DllImport("kernel32", SetLastError = true)]
+		private static extern IntPtr LoadLibrary(string lpFileName);
+		
+		#region Imported NLOpt functions - .NET Framework
+		
+		#if NETFRAMEWORK
+		
+		static NLoptSolver()
+		{
+			LoadLibrary($"nlopt_{Subscript}.dll");
+		}
+		
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_version), CallingConvention = CallingConvention.Cdecl)]
+		private static extern void nlopt_version64(out int major, out int minor, out int bugfix);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_version), CallingConvention = CallingConvention.Cdecl)]
+		private static extern void nlopt_version32(out int major, out int minor, out int bugfix);
+		
+		private static void nlopt_version(out int major, out int minor, out int bugfix)
+		{
+			if (Is64Bit)
+			{
+				nlopt_version64(out major, out minor, out bugfix);
+				return;
+			}
+
+			nlopt_version32(out major, out minor, out bugfix);
+		}
+
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_create), CallingConvention = CallingConvention.Cdecl)]
+		private static extern IntPtr nlopt_create64(NLoptAlgorithm algorithm, uint n);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_create), CallingConvention = CallingConvention.Cdecl)]
+		private static extern IntPtr nlopt_create32(NLoptAlgorithm algorithm, uint n);
+
+		private static IntPtr nlopt_create(NLoptAlgorithm algorithm, uint n)
+			=> Is64Bit ? nlopt_create64(algorithm, n) : nlopt_create32(algorithm, n);
+
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_destroy), CallingConvention = CallingConvention.Cdecl)]
+		private static extern void nlopt_destroy64(IntPtr opt);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_destroy), CallingConvention = CallingConvention.Cdecl)]
+		private static extern void nlopt_destroy32(IntPtr opt);
+
+		private static void nlopt_destroy(IntPtr opt)
+		{
+			if (Is64Bit)
+			{
+				nlopt_destroy64(opt);
+				return;
+			}
+
+			nlopt_destroy32(opt);
+		}
+
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_optimize), CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+		private static extern NloptResult nlopt_optimize64(IntPtr opt, double[] x, ref double result);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_optimize), CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+		private static extern NloptResult nlopt_optimize32(IntPtr opt, double[] x, ref double result);
+
+		private static NloptResult nlopt_optimize(IntPtr opt, double[] x, ref double result)
+			=> Is64Bit ? nlopt_optimize64(opt, x, ref result) : nlopt_optimize32(opt, x, ref result);
+
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_set_min_objective), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_min_objective64(IntPtr opt, nlopt_func f, IntPtr data);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_set_min_objective), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_min_objective32(IntPtr opt, nlopt_func f, IntPtr data);
+
+		private static NloptResult nlopt_set_min_objective(IntPtr opt, nlopt_func f, IntPtr data)
+			=> Is64Bit ? nlopt_set_min_objective64(opt, f, data) : nlopt_set_min_objective32(opt, f, data);
+
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_set_max_objective), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_max_objective64(IntPtr opt, nlopt_func f, IntPtr data);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_set_max_objective), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_max_objective32(IntPtr opt, nlopt_func f, IntPtr data);
+
+		private static NloptResult nlopt_set_max_objective(IntPtr opt, nlopt_func f, IntPtr data)
+			=> Is64Bit ? nlopt_set_max_objective64(opt, f, data) : nlopt_set_max_objective32(opt, f, data);
+
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_get_algorithm), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NLoptAlgorithm nlopt_get_algorithm64(IntPtr opt);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_get_algorithm), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NLoptAlgorithm nlopt_get_algorithm32(IntPtr opt);
+
+		private static NLoptAlgorithm nlopt_get_algorithm(IntPtr opt)
+			=> Is64Bit ? nlopt_get_algorithm64(opt) : nlopt_get_algorithm32(opt);
+
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_get_dimension), CallingConvention = CallingConvention.Cdecl)]
+		private static extern uint nlopt_get_dimension64(IntPtr opt);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_get_dimension), CallingConvention = CallingConvention.Cdecl)]
+		private static extern uint nlopt_get_dimension32(IntPtr opt);
+
+		private static uint nlopt_get_dimension(IntPtr opt)
+			=> Is64Bit ? nlopt_get_dimension64(opt) : nlopt_get_dimension32(opt);
+
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_set_lower_bounds), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_lower_bounds64(IntPtr opt, double[] lowerBounds);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_set_lower_bounds), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_lower_bounds32(IntPtr opt, double[] lowerBounds);
+
+		private static NloptResult nlopt_set_lower_bounds(IntPtr opt, double[] lowerBounds)
+			=> Is64Bit ? nlopt_set_lower_bounds64(opt, lowerBounds) : nlopt_set_lower_bounds32(opt, lowerBounds);
+
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_set_upper_bounds), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_upper_bounds64(IntPtr opt, double[] upperBounds);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_set_upper_bounds), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_upper_bounds32(IntPtr opt, double[] upperBounds);
+
+		private static NloptResult nlopt_set_upper_bounds(IntPtr opt, double[] upperBounds)
+			=> Is64Bit ? nlopt_set_upper_bounds64(opt, upperBounds) : nlopt_set_upper_bounds32(opt, upperBounds);
+
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_add_inequality_constraint), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_add_inequality_constraint64(IntPtr opt, nlopt_func fc, IntPtr data, double tolerance);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_add_inequality_constraint), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_add_inequality_constraint32(IntPtr opt, nlopt_func fc, IntPtr data, double tolerance);
+
+		private static NloptResult nlopt_add_inequality_constraint(IntPtr opt, nlopt_func fc, IntPtr data, double tolerance)
+			=> Is64Bit ? nlopt_add_inequality_constraint64(opt, fc, data, tolerance) : nlopt_add_inequality_constraint32(opt, fc, data, tolerance);
+
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_add_equality_constraint), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_add_equality_constraint64(IntPtr opt, nlopt_func fc, IntPtr data, double tolerance);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_add_equality_constraint), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_add_equality_constraint32(IntPtr opt, nlopt_func fc, IntPtr data, double tolerance);
+
+		private static NloptResult nlopt_add_equality_constraint(IntPtr opt, nlopt_func fc, IntPtr data, double tolerance)
+			=> Is64Bit ? nlopt_add_equality_constraint64(opt, fc, data, tolerance) : nlopt_add_equality_constraint32(opt, fc, data, tolerance);
+
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_add_equality_mconstraint), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_add_equality_mconstraint64(IntPtr opt, uint m, nlopt_mfunc fc, IntPtr data, double[] tolerances);
+		
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_add_equality_mconstraint), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_add_equality_mconstraint32(IntPtr opt, uint m, nlopt_mfunc fc, IntPtr data, double[] tolerances);
+		
+		private static NloptResult nlopt_add_equality_mconstraint(IntPtr opt, uint m, nlopt_mfunc fc, IntPtr data, double[] tolerances)
+			=> Is64Bit ? nlopt_add_equality_mconstraint64(opt, m, fc, data, tolerances) : nlopt_add_equality_mconstraint32(opt, m, fc, data, tolerances);
+
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_add_inequality_mconstraint), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_add_inequality_mconstraint64(IntPtr opt, uint m, nlopt_mfunc fc, IntPtr data, double[] tolerances);
+		
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_add_inequality_mconstraint), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_add_inequality_mconstraint32(IntPtr opt, uint m, nlopt_mfunc fc, IntPtr data, double[] tolerances);
+		
+		private static NloptResult nlopt_add_inequality_mconstraint(IntPtr opt, uint m, nlopt_mfunc fc, IntPtr data, double[] tolerances)
+			=> Is64Bit ? nlopt_add_inequality_mconstraint64(opt, m, fc, data, tolerances) : nlopt_add_inequality_mconstraint32(opt, m, fc, data, tolerances);
+		
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_set_xtol_rel), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_xtol_rel64(IntPtr opt, double tolerance);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_set_xtol_rel), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_xtol_rel32(IntPtr opt, double tolerance);
+
+		private static NloptResult nlopt_set_xtol_rel(IntPtr opt, double tolerance)
+			=> Is64Bit ? nlopt_set_xtol_rel64(opt, tolerance) : nlopt_set_xtol_rel32(opt, tolerance);
+
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_set_local_optimizer), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_local_optimizer64(IntPtr opt, IntPtr local);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_set_local_optimizer), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_local_optimizer32(IntPtr opt, IntPtr local);
+
+		private static NloptResult nlopt_set_local_optimizer(IntPtr opt, IntPtr local)
+			=> Is64Bit ? nlopt_set_local_optimizer64(opt, local) : nlopt_set_local_optimizer32(opt, local);
+
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_set_maxeval), CallingConvention = CallingConvention.Cdecl)]
+		private static extern void nlopt_set_maxeval64(IntPtr opt, int maxeval);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_set_maxeval), CallingConvention = CallingConvention.Cdecl)]
+		private static extern void nlopt_set_maxeval32(IntPtr opt, int maxeval);
+
+		private static void nlopt_set_maxeval(IntPtr opt, int maxeval)
+		{
+			if (Is64Bit)
+			{
+				nlopt_set_maxeval64(opt, maxeval);
+				return;
+			}
+
+			nlopt_set_maxeval32(opt, maxeval);
+		}
+		
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_force_stop), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_force_stop64(IntPtr opt);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_force_stop), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_force_stop32(IntPtr opt);
+
+		private static NloptResult nlopt_force_stop(IntPtr opt)
+		{
+			return Is64Bit ? nlopt_force_stop64(opt) : nlopt_force_stop32(opt);
+		}
+	        
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_set_initial_step), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_initial_step64(IntPtr opt, double[] dx);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_set_initial_step), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_initial_step32(IntPtr opt, double[] dx);
+
+		private static NloptResult nlopt_set_initial_step(IntPtr opt, double[] dx)
+			=> Is64Bit ? nlopt_set_initial_step64(opt, dx) : nlopt_set_initial_step32(opt, dx);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_initial_step1(IntPtr opt, double dx);
+
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_set_ftol_rel), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_ftol_rel64(IntPtr opt, double tol);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_set_ftol_rel), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_ftol_rel32(IntPtr opt, double tol);
+
+		private static NloptResult nlopt_set_ftol_rel(IntPtr opt, double tol)
+			=> Is64Bit ? nlopt_set_ftol_rel64(opt, tol) : nlopt_set_ftol_rel32(opt, tol);
+
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_set_ftol_abs), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_ftol_abs64(IntPtr opt, double tol);
+
+		[DllImport(NLopt32, EntryPoint = nameof(nlopt_set_ftol_abs), CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_ftol_abs32(IntPtr opt, double tol);
+
+		private static NloptResult nlopt_set_ftol_abs(IntPtr opt, double tol)
+			=> Is64Bit ? nlopt_set_ftol_abs64(opt, tol) : nlopt_set_ftol_abs32(opt, tol);
+
+		[DllImport(NLopt64, EntryPoint = nameof(nlopt_set_xtol_abs1), CallingConvention = CallingConvention.Cdecl)]
+	    private static extern NloptResult nlopt_set_xtol_abs164(IntPtr opt, double tol);
+
+	    [DllImport(NLopt32, EntryPoint = nameof(nlopt_set_xtol_abs1), CallingConvention = CallingConvention.Cdecl)]
+	    private static extern NloptResult nlopt_set_xtol_abs132(IntPtr opt, double tol);
+
+	    private static NloptResult nlopt_set_xtol_abs1(IntPtr opt, double tol)
+		    => Is64Bit ? nlopt_set_xtol_abs164(opt, tol) : nlopt_set_xtol_abs132(opt, tol);
+
+	    [DllImport(NLopt64, EntryPoint = nameof(nlopt_set_xtol_abs), CallingConvention = CallingConvention.Cdecl)]
+        private static extern NloptResult nlopt_set_xtol_abs64(IntPtr opt, double tol);
+
+        [DllImport(NLopt32, EntryPoint = nameof(nlopt_set_xtol_abs), CallingConvention = CallingConvention.Cdecl)]
+        private static extern NloptResult nlopt_set_xtol_abs32(IntPtr opt, double tol);
+
+        private static NloptResult nlopt_set_xtol_abs(IntPtr opt, double tol)
+	        => Is64Bit ? nlopt_set_xtol_abs64(opt, tol) : nlopt_set_xtol_abs32(opt, tol);
+
+        [DllImport(NLopt64, EntryPoint = nameof(nlopt_get_ftol_rel), CallingConvention = CallingConvention.Cdecl)]
+		private static extern double nlopt_get_ftol_rel64(IntPtr opt);
+
+	    [DllImport(NLopt32, EntryPoint = nameof(nlopt_get_ftol_rel), CallingConvention = CallingConvention.Cdecl)]
+	    private static extern double nlopt_get_ftol_rel32(IntPtr opt);
+
+	    private static double nlopt_get_ftol_rel(IntPtr opt)
+		    => Is64Bit ? nlopt_get_ftol_rel64(opt) : nlopt_get_ftol_rel32(opt);
+
+	    [DllImport(NLopt64, EntryPoint = nameof(nlopt_get_ftol_abs), CallingConvention = CallingConvention.Cdecl)]
+	    private static extern double nlopt_get_ftol_abs64(IntPtr opt);
+
+	    [DllImport(NLopt32, EntryPoint = nameof(nlopt_get_ftol_abs), CallingConvention = CallingConvention.Cdecl)]
+	    private static extern double nlopt_get_ftol_abs32(IntPtr opt);
+
+	    private static double nlopt_get_ftol_abs(IntPtr opt)
+		    => Is64Bit ? nlopt_get_ftol_abs64(opt) : nlopt_get_ftol_abs32(opt);
+
+	    [DllImport(NLopt64, EntryPoint = nameof(nlopt_get_xtol_rel), CallingConvention = CallingConvention.Cdecl)]
+	    private static extern double nlopt_get_xtol_rel64(IntPtr opt);
+
+	    [DllImport(NLopt32, EntryPoint = nameof(nlopt_get_xtol_rel), CallingConvention = CallingConvention.Cdecl)]
+	    private static extern double nlopt_get_xtol_rel32(IntPtr opt);
+
+	    private static double nlopt_get_xtol_rel(IntPtr opt)
+		    => Is64Bit ? nlopt_get_xtol_rel64(opt) : nlopt_get_xtol_rel32(opt);
+
+	    [DllImport(NLopt64, EntryPoint = nameof(nlopt_get_xtol_abs), CallingConvention = CallingConvention.Cdecl)]
+        private static extern double nlopt_get_xtol_abs64(IntPtr opt);
+
+        [DllImport(NLopt32, EntryPoint = nameof(nlopt_get_xtol_abs), CallingConvention = CallingConvention.Cdecl)]
+        private static extern double nlopt_get_xtol_abs32(IntPtr opt);
+
+        private static double nlopt_get_xtol_abs(IntPtr opt)
+	        => Is64Bit ? nlopt_get_xtol_abs64(opt) : nlopt_get_xtol_abs32(opt);
+
+        #endif
+        
+        #endregion
+	}
+}

--- a/NLoptNet/NLoptSolver_netstandard.cs
+++ b/NLoptNet/NLoptSolver_netstandard.cs
@@ -1,0 +1,95 @@
+﻿namespace NLoptNet
+{
+	using System;
+	using System.Runtime.InteropServices;
+	
+    public partial class NLoptSolver
+    {
+		#region Imported NLOpt functions - .NET Standard
+		
+		#if NETSTANDARD
+		
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern void nlopt_version(out int major, out int minor, out int bugfix);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern IntPtr nlopt_create(NLoptAlgorithm algorithm, uint n);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern void nlopt_destroy(IntPtr opt);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+		private static extern NloptResult nlopt_optimize(IntPtr opt, double[] x, ref double result);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_min_objective(IntPtr opt, nlopt_func f, IntPtr data);
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_max_objective(IntPtr opt, nlopt_func f, IntPtr data);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NLoptAlgorithm nlopt_get_algorithm(IntPtr opt);
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern uint nlopt_get_dimension(IntPtr opt);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_lower_bounds(IntPtr opt, double[] lowerBounds);
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_upper_bounds(IntPtr opt, double[] upperBounds);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_add_inequality_constraint(IntPtr opt, nlopt_func fc, IntPtr data, double tolerance);
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_add_equality_constraint(IntPtr opt, nlopt_func fc, IntPtr data, double tolerance);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_add_equality_mconstraint(IntPtr opt, uint m, nlopt_mfunc fc, IntPtr data, double[] tolerances);
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_add_inequality_mconstraint(IntPtr opt, uint m, nlopt_mfunc fc, IntPtr data, double[] tolerances);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_xtol_rel(IntPtr opt, double tolerance);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_local_optimizer(IntPtr opt, IntPtr local);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern void nlopt_set_maxeval(IntPtr opt, int maxeval);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_force_stop(IntPtr opt);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_initial_step(IntPtr opt, double[] dx);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_initial_step1(IntPtr opt, double dx);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_ftol_rel(IntPtr opt, double tol);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_ftol_abs(IntPtr opt, double tol);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_xtol_abs1(IntPtr opt, double tol);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_set_xtol_abs(IntPtr opt, double[] tol);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern double nlopt_get_ftol_rel(IntPtr opt);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern double nlopt_get_ftol_abs(IntPtr opt);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern double nlopt_get_xtol_rel(IntPtr opt);
+
+		[DllImport("nlopt", CallingConvention = CallingConvention.Cdecl)]
+		private static extern NloptResult nlopt_get_xtol_abs(IntPtr opt, out double[] tol);
+
+		#endif
+		
+		#endregion
+    }
+}

--- a/NLoptNet/Properties/AssemblyInfo.cs
+++ b/NLoptNet/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.0.0")]
-[assembly: AssemblyFileVersion("1.3.0.0")]
+[assembly: AssemblyVersion("1.4.0.0")]
+[assembly: AssemblyFileVersion("1.4.0.0")]


### PR DESCRIPTION
This PR resolves #20 and adds support for .NET Framework 4.7 and higher, as well as retaining support for the more modern .NET Core and .NET 5.0/6.0 frameworks, by delivering a .NET Standard 2.0 DLL package (as was present before).

Downstream users should no longer have the need to use LoadLibrary to load the native nlopt DLL in their applications, this should all be done by the NLoptNet package going forward.